### PR TITLE
Add import/export dialogs for .fas files

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -8,6 +8,28 @@ use std::{
 };
 
 #[derive(PartialEq, Eq, Copy, Clone)]
+pub(super) enum FileDialogMode {
+    Import,
+    Export,
+}
+
+pub(super) struct FileDialog {
+    pub mode: FileDialogMode,
+    pub path: String,
+    pub error: Option<String>,
+}
+
+impl FileDialog {
+    pub fn new(mode: FileDialogMode) -> Self {
+        Self {
+            mode,
+            path: String::new(),
+            error: None,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub(super) enum Tab {
     Editor,
     Run,
@@ -60,6 +82,9 @@ pub struct App {
 
     // Docs state
     pub(super) docs_scroll: usize,
+
+    // Import/export dialog
+    pub(super) file_dialog: Option<FileDialog>,
 }
 
 impl App {
@@ -94,6 +119,7 @@ impl App {
             last_step_time: Instant::now(),
             step_interval: Duration::from_millis(80),
             docs_scroll: 0,
+            file_dialog: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- add file dialog state to open and save .fas assembly files
- map Ctrl+O/Ctrl+S to import/export with a popup input window
- render a centered dialog to enter paths and handle errors

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0885854308333b39d1559a0d1247a