### PR TITLE
Add .word directive support in assembler data section

### DIFF
--- a/src/falcon/asm/mod.rs
+++ b/src/falcon/asm/mod.rs
@@ -72,6 +72,13 @@ pub fn assemble(text: &str, base_pc: u32) -> Result<Program, String> {
                         data_bytes.push(v as u8);
                         pc_data += 1;
                     }
+                } else if let Some(rest) = line.strip_prefix(".word") {
+                    for w in rest.split(',') {
+                        let v = parse_imm(w).ok_or_else(|| format!(".word inválido: {w}"))?;
+                        let bytes = (v as u32).to_le_bytes();
+                        data_bytes.extend_from_slice(&bytes);
+                        pc_data += 4;
+                    }
                 } else {
                     return Err(format!("diretiva de dados desconhecida: {line}"));
                 }


### PR DESCRIPTION
## Summary
- handle `.word` directives in data section
- convert values to `u32` and append as four bytes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0901b44708333ab6f23c1c6c50b9d