### PR TITLE
Add push/pop pseudo instructions and safer stack handling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,8 @@ Labels (`label:`) can be defined in any segment. To load a label address, use th
 - `jr rs1` → `jalr x0, rs1, 0`
 - `ret` → `jalr x0, ra, 0`
 - `la rd, label` → loads the address of `label`
+- `push rs` → `addi sp, sp, -4` ; `sw rs, 0(sp)`
+- `pop rd` → `lw rd, 0(sp)` ; `addi sp, sp, 4`
 
 ## Registers and Memory
 

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -141,7 +141,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> io::Result<bool> {
                     app.single_step();
                 }
                 (KeyCode::Char('r'), Tab::Run) => {
-                    app.is_running = true;
+                    if !app.faulted {
+                        app.is_running = true;
+                    }
                 }
                 (KeyCode::Char('p'), Tab::Run) => {
                     app.is_running = false;


### PR DESCRIPTION

- support `push` and `pop` pseudo instructions
- initialize stack pointer within RAM and halt on segfaults
- document push/pop usage
