### PR TITLE
Add mouse-based selection and tab indentation

### DIFF
--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -136,6 +136,26 @@ impl Editor {
         }
     }
 
+    pub fn tab(&mut self) {
+        if let Some(((sr, _), (er, _))) = self.selection_range() {
+            for row in sr..=er {
+                if row < self.lines.len() {
+                    self.lines[row].insert_str(0, "    ");
+                }
+            }
+            if let Some((ar, ac)) = self.selection_anchor {
+                if ar >= sr && ar <= er {
+                    self.selection_anchor = Some((ar, ac + 4));
+                }
+            }
+            if self.cursor_row >= sr && self.cursor_row <= er {
+                self.cursor_col += 4;
+            }
+        } else {
+            self.insert_spaces(4);
+        }
+    }
+
     pub fn backspace(&mut self) {
         if let Some((start, end)) = self.selection_range() {
             self.delete_range(start, end);

--- a/src/ui/input/keyboard.rs
+++ b/src/ui/input/keyboard.rs
@@ -124,7 +124,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> io::Result<bool> {
                     KeyCode::Backspace => app.editor.backspace(),
                     KeyCode::Delete => app.editor.delete_char(),
                     KeyCode::Enter => app.editor.enter(),
-                    KeyCode::Tab => app.editor.insert_spaces(4), // use spaces to avoid cursor width issues
+                    KeyCode::Tab => app.editor.tab(),
                     KeyCode::Char(c) => app.editor.insert_char(c), // includes '1'/'2'
                     _ => {}
                 },


### PR DESCRIPTION

- allow mouse clicks and drags to position cursor and select text in the editor
- indent selected lines by four spaces when pressing Tab
