### PR TITLE
Fix mouse click cursor offset and expand data directives

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,12 @@ The assembler accepts code split into segments:
 Inside `.data` the following directives are supported:
 
 - `.byte v1, v2, ...` – 8-bit values
+- `.half h1, h2, ...` – 16-bit values
 - `.word w1, w2, ...` – 32-bit values in little-endian
+- `.dword d1, d2, ...` – 64-bit values in little-endian
+- `.ascii "text"` – raw bytes
+- `.asciz "text"` / `.string "text"` – string with NUL terminator
+- `.space n` / `.zero n` – n zero bytes
 
 Labels (`label:`) can be defined in any segment. To load a label address, use the `la rd, label` pseudo-instruction, which emits a `lui`/`addi` pair.
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -182,7 +182,12 @@ Other formats (I, S, B, U, J) rearrange fields and immediates.
   - `.data` starts the data section (allocated from `base_pc + 0x1000`).
   - Inside `.data`:
     - `.byte` inserts 8-bit values.
+    - `.half` inserts 16-bit values.
     - `.word` inserts 32-bit words.
+    - `.dword` inserts 64-bit words.
+    - `.ascii "text"` emits raw bytes.
+    - `.asciz "text"` / `.string "text"` emit strings with a trailing zero.
+    - `.space n` / `.zero n` reserve `n` zero bytes.
 - **Loads/Stores**: syntax `imm(rs1)`.
 - **Branches/Jumps**: operand may be immediate or label. Offsets are byte-based; `B`/`J` require multiples of 2.
 - **Pseudo-instructions**:

--- a/instructions.set
+++ b/instructions.set
@@ -35,8 +35,8 @@ docs/
 
 ## Assembler
 
-- `.text` and `.data` segments (data starts at `base_pc + 0x1000`).
-- `.byte` and `.word` directives to insert values in the data section.
+ - `.text` and `.data` segments (data starts at `base_pc + 0x1000`).
+ - `.byte`, `.half`, `.word`, `.dword` for numeric data; `.ascii`, `.asciz`/`.string` for strings; `.space`/`.zero` for padding in the data section.
 - Labels in any segment; `la rd, label` emits `lui` + `addi`.
 - Other pseudo-instructions: `nop`, `mv`, `li`, `subi`, `j`, `call`, `jr`, `ret`.
 

--- a/src/ui/input/mouse.rs
+++ b/src/ui/input/mouse.rs
@@ -109,6 +109,12 @@ pub fn handle_mouse(app: &mut App, me: MouseEvent, area: Rect) {
             s
         };
 
+        let visible_h = editor_area.height.saturating_sub(2) as usize;
+        let len = app.editor.lines.len();
+        let end = (start + visible_h).min(len);
+        let num_width = end.to_string().len() as u16;
+        let gutter = num_width + 3;
+
         let within = |x: u16, y: u16| {
             x >= editor_area.x + 1
                 && x < editor_area.x + editor_area.width - 1
@@ -121,7 +127,7 @@ pub fn handle_mouse(app: &mut App, me: MouseEvent, area: Rect) {
                 if within(me.column, me.row) {
                     let y = (me.row - (editor_area.y + 1)) as usize;
                     let row = (start + y).min(app.editor.lines.len().saturating_sub(1));
-                    let x = me.column.saturating_sub(editor_area.x + 1) as usize;
+                    let x = me.column.saturating_sub(editor_area.x + 1 + gutter) as usize;
                     let col = x.min(Editor::char_count(&app.editor.lines[row]));
                     app.editor.cursor_row = row;
                     app.editor.cursor_col = col;
@@ -137,7 +143,7 @@ pub fn handle_mouse(app: &mut App, me: MouseEvent, area: Rect) {
                 if within(me.column, me.row) {
                     let y = (me.row - (editor_area.y + 1)) as usize;
                     let row = (start + y).min(app.editor.lines.len().saturating_sub(1));
-                    let x = me.column.saturating_sub(editor_area.x + 1) as usize;
+                    let x = me.column.saturating_sub(editor_area.x + 1 + gutter) as usize;
                     let col = x.min(Editor::char_count(&app.editor.lines[row]));
                     app.editor.cursor_row = row;
                     app.editor.cursor_col = col;


### PR DESCRIPTION

- correct editor mouse click calculations by accounting for gutter width
- implement more `.data` directives (`.half`, `.dword`, `.ascii`, `.asciz`, `.string`, `.space`, `.zero`)
- document all supported data directives

