### PR TITLE
Support .section directives in assembler

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ The project includes:
 
 - Instruction decoder and encoder
 - Two-pass text assembler with label support
-- `.text` and `.data` segments with data directives
+- `.text`/`.section .text` and `.data`/`.section .data` segments with data directives
 - Little-endian registers and memory
 - Execution engine ready for integration with graphical interfaces
 
@@ -30,8 +30,8 @@ Implements the essential subset of **RV32I**:
 
 The assembler accepts code split into segments:
 
-- `.text` – instruction segment.
-- `.data` – data segment, loaded **0x1000 bytes** after the program base address.
+- `.text` or `.section .text` – instruction segment.
+- `.data` or `.section .data` – data segment, loaded **0x1000 bytes** after the program base address.
 
 Inside `.data` the following directives are supported:
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -178,8 +178,8 @@ Other formats (I, S, B, U, J) rearrange fields and immediates.
 - **Comments**: anything after `;` or `#` is ignored.
 - **Separator**: `instr op1, op2, op3`.
 - **Segment directives**:
-  - `.text` starts the code section.
-  - `.data` starts the data section (allocated from `base_pc + 0x1000`).
+  - `.text` or `.section .text` starts the code section.
+  - `.data` or `.section .data` starts the data section (allocated from `base_pc + 0x1000`).
   - Inside `.data`:
     - `.byte` inserts 8-bit values.
     - `.half` inserts 16-bit values.


### PR DESCRIPTION

- allow `.section .text` and `.section .data` to select code or data sections
- document `.section` as an alternative to `.text`/`.data`
- test assembly using `.section`

